### PR TITLE
fix broken links to undum.com

### DIFF
--- a/devel/html/index.html
+++ b/devel/html/index.html
@@ -89,7 +89,7 @@
           <p>Raconteur is &copy; 2015 Bruno Dias.</p>
 
           <!-- This line is totally optional. -->
-          <p>Created with <a href="http://undum.com">Undum</a> and
+          <p>Created with <a href="https://idmillington.github.io/undum/">Undum</a> and
           <a href="http://sequitur.github.io/raconteur/">Raconteur</a>.</p>
 
         </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Raconteur
 
-Raconteur makes writing interactive hypertext fiction with Undum straightforward and perphaps even fun. Raconteur however is only a wrapper layer on top of the Undum hypertext fiction engine; for this reason, this documentation will include references to Undum API features as well. Feel free to consult the [Undum documentation](http://undum.com/doc/index.html) itself.
+Raconteur makes writing interactive hypertext fiction with Undum straightforward and perphaps even fun. Raconteur however is only a wrapper layer on top of the Undum hypertext fiction engine; for this reason, this documentation will include references to Undum API features as well. Feel free to consult the [Undum documentation](https://idmillington.github.io/undum/doc/index.html) itself.
 
 **This is version 1 of this documentation, updated on September 30th, 2015.**
 


### PR DESCRIPTION
In addition to the two links I fixed in this PR, https://sequitur.github.io/raconteur/ has a very prominent broken link to undum.com that should be changed to https://idmillington.github.io/undum/